### PR TITLE
Pass Buildkite the author information

### DIFF
--- a/src/applications/differential/storage/DifferentialDiff.php
+++ b/src/applications/differential/storage/DifferentialDiff.php
@@ -642,6 +642,17 @@ final class DifferentialDiff
     return 'HEAD';
   }
 
+  public function getBuildkiteAuthor() {
+    $author = id(new PhabricatorUser())->loadOneWhere(
+      'phid = %s',
+      $this->getAuthorPHID());
+
+    return array(
+      'name' => $author->getRealName(),
+      'email' => $author->loadPrimaryEmailAddress(),
+    );
+  }
+
 
   public function getStagingRef() {
     // TODO: We're just hoping to get lucky. Instead, `arc` should store

--- a/src/applications/harbormaster/interface/HarbormasterBuildkiteBuildableInterface.php
+++ b/src/applications/harbormaster/interface/HarbormasterBuildkiteBuildableInterface.php
@@ -7,5 +7,6 @@ interface HarbormasterBuildkiteBuildableInterface {
 
   public function getBuildkiteBranch();
   public function getBuildkiteCommit();
+  public function getBuildkiteAuthor();
 
 }

--- a/src/applications/harbormaster/step/HarbormasterBuildkiteBuildStepImplementation.php
+++ b/src/applications/harbormaster/step/HarbormasterBuildkiteBuildStepImplementation.php
@@ -91,6 +91,7 @@ EOTEXT
     $data_structure = array(
       'commit' => $object->getBuildkiteCommit(),
       'branch' => $object->getBuildkiteBranch(),
+      'author' => $object->getBuildkiteAuthor(),
       'message' => pht(
         'Harbormaster Build %s ("%s") for %s',
         $build->getID(),

--- a/src/applications/repository/storage/PhabricatorRepositoryCommit.php
+++ b/src/applications/repository/storage/PhabricatorRepositoryCommit.php
@@ -628,6 +628,16 @@ final class PhabricatorRepositoryCommit
     return $this->getCommitIdentifier();
   }
 
+  public function getBuildkiteAuthor() {
+    $author = id(new PhabricatorUser())->loadOneWhere(
+      'phid = %s',
+      $this->getAuthorPHID());
+
+    return array(
+      'name' => $author->getRealName(),
+      'email' => $author->loadPrimaryEmailAddress(),
+    );
+  }
 
 /* -(  PhabricatorCustomFieldInterface  )------------------------------------ */
 


### PR DESCRIPTION
As per https://secure.phabricator.com/T12251 and https://secure.phabricator.com/T12794 there's currently no author information being sent to Buildkite, so Buildkite is unable to attribute builds to the correct people.

For example:

```json
{"commit":"HEAD","branch":"phabricator\/diff\/2","message":"Harbormaster Build 3 (\"Buildkite Test Pipeline\") for B2","env":{"HARBORMASTER_BUILD_TARGET_PHID":"PHID-HMBT-5q2sbvfsafszrkjlkigh"},"meta_data":{"buildTargetPHID":"PHID-HMBT-5q2sbvfsafszrkjlkigh"}}
```

This adds the authorship information to the Buildkite payload, using the author’s name and primary email address, so builds are correctly associated with the correct Buildkite users:

```json
{"commit":"HEAD","branch":"phabricator\/diff\/2","author":{"name":"Phabicator User","email":"user@user.com"},"message":"Harbormaster Build 3 (\"Buildkite Test Pipeline\") for B2","env":{"HARBORMASTER_BUILD_TARGET_PHID":"PHID-HMBT-5q2sbvfsafszrkjlkigh"},"meta_data":{"buildTargetPHID":"PHID-HMBT-5q2sbvfsafszrkjlkigh"}}
```